### PR TITLE
CROPS-26 Disable blog form when user does not have a profile

### DIFF
--- a/luggage_blog.module
+++ b/luggage_blog.module
@@ -46,11 +46,11 @@ function luggage_blog_form_alter(&$form, &$form_state, $form_id) {
         // TODO: This needs to be cleaned up a bit to look better
         $form['field_lug_blog_author']['#markup'] = $prefix . $profile->title . $suffix;
       }
-      // if there is not a matching author, prompt the user to create their profile.
       else {
+        // if there is not a matching author, prompt the user to create their profile.
         drupal_set_message(t('You must <a href="'.$GLOBALS['base_path'].'my/profile">create your profile</a> before creating a blog entry.'), 'warning');
-        // hide the empty field
         $form['field_lug_blog_author']['#markup'] = ' ';
+        $form['#disabled'] = TRUE;
       }
 
     }


### PR DESCRIPTION
Disables the whole blog post form when the user does not have a profile:

![image](https://cloud.githubusercontent.com/assets/108130/8010303/71f0844a-0baf-11e5-9bbf-524a1c40af9b.png)
