### PR TITLE
CROPS-165 Updating blog date format

### DIFF
--- a/luggage_blog.module
+++ b/luggage_blog.module
@@ -10,10 +10,18 @@ include_once 'luggage_blog.features.inc';
  * Implements theme_preprocess_node()
  */
 function luggage_blog_preprocess_node(&$vars) {
-  // rewrite the display of the "Display author and date information" to be nicer for only
+  // Rewrite the display of the "Display author and date information" to be nicer for only
   // blog posts.
-  if($vars['submitted'] && $vars['type'] == "lug_blog") {
-    $vars['submitted'] = t("%datetime",
-      array('%datetime' => format_date($vars['node']->created, 'news')));
+  if ($vars['submitted'] && $vars['type'] == "lug_blog") {
+    // Search results and teasers: February 25, 2016 
+    if ($vars['teaser'] || $vars['view_mode'] == 'search_result') {
+      $vars['submitted'] = t("%datetime",
+        array('%datetime' => format_date($vars['node']->created, 'custom', 'F j, Y')));
+    }
+    else {
+      // Otherwise use the format defined by luggage_news
+      $vars['submitted'] = t("%datetime",
+        array('%datetime' => format_date($vars['node']->created, 'news')));
+    }
   }
 }


### PR DESCRIPTION
An update for the blog date format, as per John's code in the Jira ticket. Makes blog date formats the same as ICM news date formats.

Test: Pull down these changes
Make a new blog post
View your blog post, confirm that its date format is "day, mm/dd/yyyy - hr:min"
Look at the view and confirm its date is "Month dd, yyyy"
Find your blog post in a search result and confirm its date is "Month dd, yyyy"
