### PR TITLE
LUGG-1193 Increase image insertion width

### DIFF
--- a/luggage_blog.features.field_instance.inc
+++ b/luggage_blog.features.field_instance.inc
@@ -358,7 +358,7 @@ function luggage_blog_field_default_field_instances() {
           'image_thumbnail' => 0,
           'link' => 0,
         ),
-        'insert_width' => 300,
+        'insert_width' => 852,
         'preview_image_style' => 'thumbnail',
         'progress_indicator' => 'throbber',
       ),


### PR DESCRIPTION
To test:
- Pull down a fresh Luggage site
- Check out this branch
- Revert the blog feature
- Upload an image with a width greater than 300 pixels. Is it tiny?